### PR TITLE
Firefox でもカードをドラッグできるようにする

### DIFF
--- a/app/components/card-wrapper/card-wrapper.js
+++ b/app/components/card-wrapper/card-wrapper.js
@@ -73,7 +73,7 @@ export default {
   },
 
   events: {
-    mouseDownCard(cardVM) {
+    mouseDownCard(event, cardVM) {
       // detect mouse position
       const elPosition = getAbsolutePosition(this.$el);
       const x = event.pageX - elPosition.x;

--- a/app/components/card/card.js
+++ b/app/components/card/card.js
@@ -105,7 +105,7 @@ export default {
     },
 
     onMouseDown(event) {
-      this.$dispatch('mouseDownCard', this);
+      this.$dispatch('mouseDownCard', event, this);
     }
   },
 


### PR DESCRIPTION
Fix #8 

普通にエラー出てました。
むしろ今まで Chrome で動いてたのが謎。
